### PR TITLE
Use ref in UnsafeStruct write

### DIFF
--- a/jettnet/jettnet/Core/Core.cs
+++ b/jettnet/jettnet/Core/Core.cs
@@ -302,7 +302,7 @@ namespace jettnet // v1.3
 
                         if (freeBytesInBuffer < sizeOfStructure)
                         {
-                            throw new Exception("Buffer to small.  Bytes available: " + freeBytesInBuffer + " size of struct: " + sizeOfStructure);
+                            throw new Exception("Buffer too small.  Bytes available: " + freeBytesInBuffer + " size of struct: " + sizeOfStructure);
                         }
 
                         Buffer.MemoryCopy(unmanagedStructPtr, dataPtr, freeBytesInBuffer, sizeOfStructure);


### PR DESCRIPTION
Changed WriteUnmanagedStruct() to take in a reference to the struct instead of copying the whole struct into the function.
ReadUnmanagedStruct() already takes in a ref

It's pretty cheap to copy a 1200byte struct into the calling function, so it may be worth writing an overload function that doesn't use ref, but I think the caller should be the one to handle thread safety and let this function stay as fast as possible by using `ref`.  Its whole purpose is to be the fastest possible method to serialize/deserialize